### PR TITLE
Do not overwrite page:load

### DIFF
--- a/vendor/assets/javascripts/twitter-bootstrap-calendar/index.js
+++ b/vendor/assets/javascripts/twitter-bootstrap-calendar/index.js
@@ -10,10 +10,6 @@ function tbsCalendarSetMaxHeight(){
   });
 }
 
-$(document).on('page:load', function() {
-  tbsCalendarSetMaxHeight();
-});
-
 $(document).ready(function() {
   tbsCalendarSetMaxHeight();
 });


### PR DESCRIPTION
Do not overwrite page:load as this disables all other bootstrap activities.
